### PR TITLE
Fix `reflect` so it calls the `thenable` in a Promise chain

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function deferred() {
  */
 
 function reflect(thenable, args) {
-  return Promise.resolve(thenable(...args))
+  return new Promise(resolve => resolve(thenable(...args)))
     .then(_.noop, _.identity);
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -167,6 +167,19 @@ describe('ProcessManager', () => {
 
       jest.runAllTimers();
     });
+
+    test('if a hook throws, it returns the error in an array', () => {
+      const error = new Error('foo');
+      const handler = () => { throw error; };
+      const name = 'disconnect';
+
+      processManager.addHook(name, handler);
+
+      return processManager.hook(name)
+        .then(errors => {
+          expect(errors).toContain(error);
+        });
+    });
   });
 
   describe('shutdown()', () => {


### PR DESCRIPTION
This PR fixes an error where the process would not shutdown because a hook would throw an error outside the Promise chain.

Closes #3 