### PR TITLE
Force shutdown if an `UncaughtException` is thrown

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,6 +186,10 @@ class ProcessManager {
     this.terminating = true;
     this.forceShutdown = deferred();
 
+    if (force) {
+      this.forceShutdown.reject();
+    }
+
     log.info('Starting shutdown.');
 
     Promise.race([Promise.all(this.running), this.forceShutdown.promise])
@@ -234,7 +238,7 @@ process.on('unhandledRejection', error => {
 process.on('uncaughtException', error => {
   log.info('Caught exception.', error);
 
-  processManager.shutdown({ error });
+  processManager.shutdown({ error, force: true });
 });
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -195,6 +195,12 @@ describe('ProcessManager', () => {
       expect(processManager.forceShutdown.promise).toBeInstanceOf(Promise);
     });
 
+    test('with `force` set to `true` it creates `forceShutdown` promise in reject state', done => {
+      processManager.shutdown({ force: true });
+
+      processManager.forceShutdown.promise.catch(done);
+    });
+
     test('calls hook `disconnect`', done => {
       spyOn(processManager, 'hook').and.callThrough();
 
@@ -263,7 +269,7 @@ describe('ProcessManager', () => {
 
     test('forces shutdown if `processManager.shutdown` is called with force `true`', done => {
       spyOn(processManager, 'exit').and.callFake(() => {
-        done();
+        processManager.forceShutdown.promise.catch(done);
       });
 
       processManager.once(function *() {
@@ -462,7 +468,7 @@ describe('ProcessManager', () => {
       const error = new Error();
 
       process.once('uncaughtException', () => {
-        expect(processManager.shutdown).toBeCalledWith({ error });
+        expect(processManager.shutdown).toBeCalledWith({ error, force: true });
 
         done();
       });


### PR DESCRIPTION
This PR makes the `shutdown` process of an `UncaughtException` immediately skip waiting for the running processes to end.

Closes #4 