### PR TITLE
Add drain hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,14 @@ processManager.addHook('<hook-name>', () => 'result');
 processManager.addHook('<hook-name>', () => Promise.resolve('result'));
 ```
 
+### drain
+
+This hook is called during shutdown, after all running processes have stopped. 
+It should be used to drain connections if the process is running a server.
+
 ### disconnect
 
-This hook is called during shutdown, after all running processes have stopped. This is where
+This hook is called after `drain` and it's where
 handlers should be added to close running services (ex.: database connections, persistent
 connections, etc).
 

--- a/index.js
+++ b/index.js
@@ -195,6 +195,12 @@ class ProcessManager {
     Promise.race([Promise.all(this.running), this.forceShutdown.promise])
       .then(() => log.info('All running instances have stopped.'))
       .catch(() => log.info('Forced shutdown, skipped waiting for instances.'))
+      .then(() => this.hook('drain'))
+      .then(errors => {
+        this.errors = _.compact(_.concat(this.errors, errors));
+
+        log.info(`${(this.hooks.drain || []).length} server(s) drained.`);
+      })
       .then(() => this.hook('disconnect'))
       .then(errors => {
         this.errors = _.compact(_.concat(this.errors, errors));

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -201,6 +201,18 @@ describe('ProcessManager', () => {
       processManager.forceShutdown.promise.catch(done);
     });
 
+    test('calls hook `drain`', done => {
+      spyOn(processManager, 'hook').and.callThrough();
+
+      processManager.addHook('drain', () => {
+        expect(processManager.hook).toBeCalledWith('drain');
+
+        done();
+      });
+
+      processManager.shutdown();
+    });
+
     test('calls hook `disconnect`', done => {
       spyOn(processManager, 'hook').and.callThrough();
 


### PR DESCRIPTION
This PR adds the `drain` hook which is intended to gracefully shutdown running services before proceeding shutdown.