### PR TITLE
Fix waiting for loop interval when ending

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,9 +122,9 @@ class ProcessManager {
   loop(fn, { interval = 0 } = {}) {
     const self = this;
 
-    return this.run(function *() {
+    return co(function *() {
       while (!self.terminating) {
-        yield fn();
+        yield self.run(fn, { exit: false });
 
         if (!self.terminating) {
           yield Promise.delay(interval);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -320,7 +320,7 @@ describe('ProcessManager', () => {
       test('calls `shutdown` with error if an error is thrown while running the loop', () => {
         const error = new Error();
 
-        spyOn(processManager, 'shutdown');
+        spyOn(processManager, 'shutdown').and.callThrough();
 
         return processManager.loop(function *() { throw error; })
         .then(() => {


### PR DESCRIPTION
This PR fixes a bug in the loop that made `shutdown` wait for `Promise.delay()` to start shutting down.