### PR TITLE
Loop with dynamic interval

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -111,10 +111,10 @@ class ProcessManager {
 
   async loop(fn, { interval = 0 } = {}) {
     while (!this.terminating) {
-      await this.run(fn, { exit: false });
+      const result = await this.run(fn, { exit: false });
 
       if (!this.terminating) {
-        await utils.timeout(interval);
+        await utils.timeout(result?.interval ?? interval);
       }
     }
   }
@@ -148,13 +148,19 @@ class ProcessManager {
 
     this.running.add(id);
 
-    const error = await utils.reflect(fn, args);
+    const result = await utils.reflect(fn, args);
 
     this.running.delete(id);
 
+    const error = result instanceof Error ? result : undefined;
+
     if (error || exit || this.terminating) {
       await this.shutdown({ error });
+
+      return;
     }
+
+    return result;
   }
 
   /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,12 +24,12 @@ module.exports.getDefaultLogger = function () {
 };
 
 /**
- * Wraps a function and makes it return undefined on success or an error if it throws.
+ * Wraps a function and makes it return the function result on success or an error if it throws.
  */
 
 module.exports.reflect = async function (thenable, args = []) {
   try {
-    await thenable(...args);
+    return await thenable(...args);
   } catch (error) {
     return error;
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -356,6 +356,33 @@ describe('ProcessManager', () => {
       expect(fn).toHaveBeenCalledTimes(3);
     });
 
+    test('handles dynamic interval', async () => {
+      const utils = require('../src/utils');
+
+      jest.spyOn(utils, 'timeout').mockImplementation(() => {});
+      const fn = jest.fn();
+
+      let i = 0;
+
+      await processManager.loop(
+        () => {
+          fn();
+
+          if (++i === 3) {
+            processManager.shutdown();
+          }
+
+          return i > 1 ? { interval: 1 } : undefined;
+        },
+        { interval: 10 }
+      );
+
+      expect(fn).toHaveBeenCalledTimes(3);
+      expect(utils.timeout).toHaveBeenCalledTimes(2);
+      expect(utils.timeout).toHaveBeenNthCalledWith(1, 10);
+      expect(utils.timeout).toHaveBeenNthCalledWith(2, 1);
+    });
+
     test('calls `shutdown` with error if an error is thrown while running the loop', async () => {
       const error = new Error();
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -31,9 +31,11 @@ describe('Utils', () => {
   });
 
   describe('reflect()', () => {
-    test('returns undefined if the passed function does not throw an error', async () => {
-      await expect(utils.reflect(() => 'foo')).resolves.toBeUndefined();
-      await expect(utils.reflect(() => Promise.resolve('foo'))).resolves.toBeUndefined();
+    test('returns the result of the the passed function', async () => {
+      await expect(utils.reflect(() => {})).resolves.toBeUndefined();
+      await expect(utils.reflect(() => 'foo')).resolves.toBe('foo');
+      await expect(utils.reflect(() => Promise.resolve('foo'))).resolves.toBe('foo');
+      await expect(utils.reflect(() => Promise.resolve({ foo: 1 }))).resolves.toEqual({ foo: 1 });
     });
 
     test('returns an error if the passed function throws an error', async () => {


### PR DESCRIPTION
In some cases it might be desirable to control when the next loop runs, for instance:
 - sooner because there's work to do, like pending tasks that could be processed;
 - later because in some periods there's no need to run often.

To address these cases, this PR takes into account the loop callback return value:
 - if the callback returns an object with `interval` key then it is used for the next loop;
 - otherwise the default loop interval is used.

This is non breaking change.