### PR TITLE
Flush stdout and stderr before exiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ processManager.addHook({
 
 ## Debug
 
-Enable verbose debugging by configuring your own logger and passing it to `proccessManager.configure({ log: myCustomLogger })`.
+Enable verbose debugging by configuring your own logger and passing it to `processManager.configure({ log: myCustomLogger })`.
 
 The minimum requirements for it to work is that the logger must be Object-like and have functions assigned to properties `info`, `warn`, and `error`.
 The functions should be able to handle two different argument signatures:

--- a/src/index.js
+++ b/src/index.js
@@ -198,7 +198,21 @@ class ProcessManager {
 
     await this.hook('exit', this.errors);
 
+    this.log.info('Flushing output');
+
+    await this.flushOutput();
+
     this.exit();
+  }
+
+  async flushOutput() {
+    // Process stdout and stderr can be in non-blocking mode so writes to it may not be flushed when the process exits.
+    // To ensure that all output is flushed before the process exits, we can write an empty string to stdout and stderr,
+    // and wait for the write operation to complete.
+    await Promise.all([
+      new Promise(resolve => process.stdout.write('', resolve)),
+      new Promise(resolve => process.stderr.write('', resolve))
+    ]);
   }
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -19,6 +19,8 @@ describe('ProcessManager', () => {
     jest.spyOn(process, 'exit').mockImplementation(() => {});
     jest.spyOn(process, 'on').mockImplementation(() => {});
     jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(process.stderr, 'write').mockImplementation((data, cb) => cb?.());
+    jest.spyOn(process.stdout, 'write').mockImplementation((data, cb) => cb?.());
 
     const utils = require('../src/utils');
 
@@ -289,6 +291,15 @@ describe('ProcessManager', () => {
       await processManager.shutdown();
 
       expect(processManager.hook).toHaveBeenCalledWith('exit', []);
+    });
+
+    test('flushes stdout and stderr', async () => {
+      await processManager.shutdown();
+
+      expect(process.stdout.write).toHaveBeenCalledTimes(1);
+      expect(process.stdout.write).toHaveBeenCalledWith('', expect.any(Function));
+      expect(process.stderr.write).toHaveBeenCalledTimes(1);
+      expect(process.stderr.write).toHaveBeenCalledWith('', expect.any(Function));
     });
 
     test('calls `processManager.exit()`', async () => {


### PR DESCRIPTION
If we do:

```js
processManager.once(() => {
  console.log('Very long line...........................');
});
```

and the process stdout is in [non blocking mode ](https://nodejs.org/api/process.html#a-note-on-process-io), the line gets truncated. This happens because process manager calls `process.exit()` before waiting for stdout to flush