### PR TITLE
Remove useless log

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -275,8 +275,6 @@ process.on('SIGTERM', () => {
   processManager.shutdown();
 });
 
-processManager.log.info('Process manager initialized');
-
 /**
  * Export `processManager`.
  */


### PR DESCRIPTION
Also the log was being done too soon, before giving the oportunity to call `configure` to set the logger.