### PR TITLE
Remove `DEBUG` check to fallback to console.error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,13 +67,6 @@ class ProcessManager {
       this.log.error(`Exiting with ${this.errors.length} error${this.errors.length > 1 ? 's' : ''}`);
       this.errors.forEach(err => this.log.error(err));
 
-      // Output console to error in case no `DEBUG` namespace has been set.
-      // This mimicks the default node behaviour of not silencing errors.
-      if (!process.env.DEBUG) {
-        // eslint-disable-next-line no-console
-        console.error(...this.errors);
-      }
-
       return process.exit(1);
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -151,26 +151,6 @@ describe('ProcessManager', () => {
       expect(process.exit).toHaveBeenCalled();
       expect(process.exit).toHaveBeenCalledWith(1);
     });
-
-    test('calls `console.error` if `DEBUG` is not set', () => {
-      processManager.errors = [new Error()];
-
-      processManager.exit();
-
-      expect(console.error).toHaveBeenCalled();
-      expect(console.error).toHaveBeenCalledWith(...processManager.errors);
-    });
-
-    test('does not call `console.error` if `DEBUG` is set', () => {
-      process.env.DEBUG = 'foo';
-      processManager.errors = [new Error()];
-
-      processManager.exit();
-
-      expect(console.error).not.toHaveBeenCalled();
-
-      delete process.env.DEBUG;
-    });
   });
 
   describe('hook()', () => {


### PR DESCRIPTION
This was ok to do before since we were using `debugnyan` which uses `DEBUG`. However, since we are no longer using it and instead we accept a `console` alike logger, it doesn't much sense to keep it.